### PR TITLE
Added missing punctuation in line 99

### DIFF
--- a/release/1.0.0/software-types.ttl
+++ b/release/1.0.0/software-types.ttl
@@ -96,7 +96,7 @@ stype:executableName a rdf:Property ;
     rdfs:label "hasSourceCode" ;
     :domainIncludes :SoftwareApplication , :WebAPI ;
     :rangeIncludes :SoftwareSourceCode ;
-    :source <https://github.com/schemaorg/schemaorg/issues/1032>
+    :source <https://github.com/schemaorg/schemaorg/issues/1032> ;
     rdfs:comment "Source code of the software" .
 
 :WebApplication a rdfs:Class ;


### PR DESCRIPTION
Line 99 or 100 was missing a closing ";"

    :source <https://github.com/schemaorg/schemaorg/issues/1032> 

->

    :source <https://github.com/schemaorg/schemaorg/issues/1032> ;

